### PR TITLE
Added support for new ideas of hub

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plant-monitor-server",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "scripts": {
     "startWebpack": "node backend-dev.js",

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -18,4 +18,10 @@ export const controllerConstants = {
     category: {
         CONTEXTNAME: 'category',
     },
+    board: {
+        CONTEXTNAME: 'board',
+    },
+    hub_profile: {
+        CONTEXTNAME: 'hub_profile',
+    },
 }

--- a/src/controllers/boardsController/boardsController.js
+++ b/src/controllers/boardsController/boardsController.js
@@ -1,0 +1,108 @@
+import model from 'src/models';
+import helpers from 'src/helpers';
+import { controllerConstants } from 'src/config/constants';
+import { controllerLog, logStylers } from 'src/helpers/logHelpers';
+
+
+const { board } = model;
+const contextName = controllerConstants.board.CONTEXTNAME;
+const boardControllerLog = controllerLog(contextName);
+
+const addBoard = (req, res) => {
+    const boardData = {
+        board_id: req.body.board_id,
+        board_name: req.body.board_name,
+        board_user_token: req.body.board_user_token,
+        added_timestamp: req.body.added_timestamp,
+    };
+
+    return board.create(boardData)
+                .then(boardDataSynced => {
+                    boardControllerLog(logStylers.genericSuccess('Board created successfully. Values:\n'), logStylers.values(JSON.stringify(boardDataSynced)));
+
+                    return res.status(201)
+                              .send(helpers.controllerHelpers.afterCreateSuccess(boardDataSynced, contextName, res.locals.cacheHandler))
+                }).catch(error => {
+                    boardControllerLog(logStylers.genericError('Error creating board. Message: '), logStylers.values(error.message), '\n', error.stack);
+
+                    return res.status(401)
+                              .send(helpers.responseHelpers.addFailure(contextName, error.message))
+                });
+}
+
+const getAllBoards = (req, res) => {
+    return board.findAll()
+                .then(allDBoards => {
+                    boardControllerLog(logStylers.genericSuccess('Boards fetched successfully. Values:\n'), logStylers.values(JSON.stringify(allDBoards)));
+
+                    return res.status(200)
+                              .send(helpers.controllerHelpers.afterFetchSuccess(allDBoards, contextName, res.locals.cacheHandler))
+                }).catch(error => {
+                    boardControllerLog(logStylers.genericError('Error fetching boards: '), logStylers.values(error.message), '\n', error.stack);
+
+                    return res.status(400)
+                              .send(helpers.responseHelpers.fetchFailure(contextName, error.message))
+                });
+}
+
+const updateBoard = (req, res) => {
+    const boardIdToUpdate = req.params.boardId;
+    const query = {
+        fields: Object.keys(req.body),
+        returning: true,
+        where: {
+            id: boardIdToUpdate,
+        },
+    };
+
+    req.body.updated_timestamp = new Date().toISOString();
+
+    return board.update(req.body, query)
+                .then(boardDataUpdateInformation => {
+                    const [numberOfRowsAffected, updatedBoardData] = boardDataUpdateInformation;
+
+                    //NOTE: Since this is allowed to update only a single board through the route, the updated board data will always contain a single changed row thus we are using updatedDeviceData[0];
+                    boardControllerLog(`${logStylers.genericSuccess('Board successfully updated! ')}, Old: ${logStylers.values(JSON.stringify(req.body))} New: ${logStylers.values(JSON.stringify(updatedBoardData[0]))}`);
+
+                    return res.status(202)
+                              .send(helpers.controllerHelpers.afterUpdateSuccess(updatedBoardData[0], contextName, res.locals.cacheHandler, 'update'))
+                }).catch(error => {
+                    boardControllerLog(logStylers.genericError('Error updating board: '), logStylers.values(JSON.stringify(baordIdToUpdate)), logStylers.values(error.message), error.stack);
+
+                    return res.status(402)
+                              .send(helpers.responseHelpers.updateFailure(contextName, error.message))
+                })
+}
+
+const deleteBoard = (req, res) => {
+    const boardIdToDelete = req.params.boardId;
+
+    const contextObject = {
+        id: boardIdToDelete,
+    };
+
+    const query = {
+        where: contextObject,
+    };
+
+    return board.destroy(query)
+                .then(() => {
+                    boardControllerLog(logStylers.genericSuccess('Board successfully deleted! ID: '), logStylers.values(boardIdToDelete));
+
+                    return res.status(203)
+                              .send(helpers.controllerHelpers.afterUpdateSuccess(null, contextName, res.locals.cacheHandler, 'delete'))
+                })
+                .catch((error) => {
+                    boardControllerLog(logStylers.genericError(`Error deleting board. ID: ${logStylers.values(boardIdToDelete)} `), logStylers.values(error.message), error.stack);
+
+                    return res.status(403)
+                              .send(helpers.responseHelpers.deleteFailure(contextName, error.message))
+                });
+}
+
+export default {
+    addBoard,
+    getAllBoards,
+    updateBoard,
+    deleteBoard,
+}

--- a/src/controllers/boardsController/index.js
+++ b/src/controllers/boardsController/index.js
@@ -1,0 +1,4 @@
+import boardsController from './boardsController';
+
+
+export default boardsController;

--- a/src/controllers/hubProfilesController/hubProfilesController.js
+++ b/src/controllers/hubProfilesController/hubProfilesController.js
@@ -1,0 +1,106 @@
+import model from 'src/models';
+import helpers from 'src/helpers';
+import { controllerConstants } from 'src/config/constants';
+import { controllerLog, logStylers } from 'src/helpers/logHelpers';
+
+
+const { hub_profile } = model;
+const contextName = controllerConstants.hub_profile.CONTEXTNAME;
+const hubProfileControllerLog = controllerLog(contextName);
+
+const addHubProfile = (req, res) => {
+    const hubProfileData = {
+        name: req.body.name,
+        settings: req.body.settings,
+        added_timestamp: req.body.added_timestamp,
+    };
+
+    return hub_profile.create(hubProfileData)
+                      .then(hubProfileDataSynced => {
+                          hubProfileControllerLog(logStylers.genericSuccess('Hub profile created successfully. Values:\n'), logStylers.values(JSON.stringify(hubProfileDataSynced)));
+
+                          return res.status(201)
+                                    .send(helpers.controllerHelpers.afterCreateSuccess(hubProfileDataSynced, contextName, res.locals.cacheHandler))
+                      }).catch(error => {
+                          hubProfileControllerLog(logStylers.genericError('Error creating hub profile. Message: '), logStylers.values(error.message), '\n', error.stack);
+
+                          return res.status(401)
+                                    .send(helpers.responseHelpers.addFailure(contextName, error.message))
+                      });
+}
+
+const getAllHubProfiles = (req, res) => {
+    return hub_profile.findAll()
+                      .then(allHubProfiles => {
+                          hubProfileControllerLog(logStylers.genericSuccess('Hub profile fetched successfully. Values:\n'), logStylers.values(JSON.stringify(allHubProfiles)));
+
+                          return res.status(200)
+                                    .send(helpers.controllerHelpers.afterFetchSuccess(allHubProfiles, contextName, res.locals.cacheHandler))
+                      }).catch(error => {
+                          hubProfileControllerLog(logStylers.genericError('Error fetching hub profiles: '), logStylers.values(error.message), '\n', error.stack);
+
+                          return res.status(400)
+                                    .send(helpers.responseHelpers.fetchFailure(contextName, error.message))
+                      });
+}
+
+const updateHubProfile = (req, res) => {
+    const hubProfileIdToUpdate = req.params.hubProfileId;
+    const query = {
+        fields: Object.keys(req.body),
+        returning: true,
+        where: {
+            id: hubProfileIdToUpdate,
+        },
+    };
+
+    req.body.updated_timestamp = new Date().toISOString();
+
+    return hub_profile.update(req.body, query)
+                      .then(hubProfileDataUpdateInformation => {
+                          const [numberOfRowsAffected, updatedHubProfileData] = hubProfileDataUpdateInformation;
+
+                          //NOTE: Since this is allowed to update only a single hub profile through the route, the updated hub profile data will always contain a single changed row thus we are using updatedDeviceData[0];
+                          hubProfileControllerLog(`${logStylers.genericSuccess('Hub profile successfully updated! ')}, Old: ${logStylers.values(JSON.stringify(req.body))} New: ${logStylers.values(JSON.stringify(updatedHubProfileData[0]))}`);
+
+                          return res.status(202)
+                                    .send(helpers.controllerHelpers.afterUpdateSuccess(updatedHubProfileData[0], contextName, res.locals.cacheHandler, 'update'))
+                      }).catch(error => {
+                          hubProfileControllerLog(logStylers.genericError('Error updating hub profile: '), logStylers.values(JSON.stringify(hubProfileIdToUpdate)), logStylers.values(error.message), error.stack);
+
+                          return res.status(402)
+                                    .send(helpers.responseHelpers.updateFailure(contextName, error.message))
+                      })
+}
+
+const deleteHubProfile = (req, res) => {
+    const hubProfileIdToDelete = req.params.hubProfileId;
+
+    const contextObject = {
+        id: hubProfileIdToDelete,
+    };
+
+    const query = {
+        where: contextObject,
+    };
+
+    return hub_profile.destroy(query)
+                      .then(() => {
+                          hubProfileControllerLog(logStylers.genericSuccess('Hub profile successfully deleted! ID: '), logStylers.values(hubProfileIdToDelete));
+
+                          return res.status(203)
+                                    .send(helpers.controllerHelpers.afterUpdateSuccess(null, contextName, res.locals.cacheHandler, 'delete'))
+                      }).catch((error) => {
+                          hubProfileControllerLog(logStylers.genericError(`Error deleting hub profile. ID: ${logStylers.values(hubProfileIdToDelete)} `), logStylers.values(error.message), error.stack);
+
+                          return res.status(403)
+                                    .send(helpers.responseHelpers.deleteFailure(contextName, error.message))
+                      });
+}
+
+export default {
+    addHubProfile,
+    getAllHubProfiles,
+    updateHubProfile,
+    deleteHubProfile,
+}

--- a/src/controllers/hubProfilesController/index.js
+++ b/src/controllers/hubProfilesController/index.js
@@ -1,0 +1,4 @@
+import hubProfilesController from './hubProfilesController';
+
+
+export default hubProfilesController;

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -4,6 +4,8 @@ import usersController from './usersController';
 import rolesController from './rolesController';
 import hubsController from './hubsController';
 import categoriesController from './categoriesController';
+import boardsController from './boardsController';
+import hubProfilesController from './hubProfilesController';
 
 
 const controllers = {
@@ -13,6 +15,8 @@ const controllers = {
   rolesController,
   hubsController,
   categoriesController,
+  boardsController,
+  hubProfilesController,
 };
 
 

--- a/src/middlewares/cacheMiddlewares.js
+++ b/src/middlewares/cacheMiddlewares.js
@@ -16,7 +16,7 @@ const checkApiCache = (req, res, next) => {
 
                     res.status(200).send(helpers.responseHelpers.fetchSuccess(undefined, JSON.parse(result)));
                 } else {
-                    cacheLog(logStylers.genericFailure('NOT FOUND IN CACHE'), 'for key: ', logStylers.values(key), '\n');
+                    cacheLog(logStylers.genericFailure('NOT FOUND IN CACHE'), 'for key: ', logStylers.values(key));
 
                     next();
                 };

--- a/src/migrations/20191012141350-create-board.js
+++ b/src/migrations/20191012141350-create-board.js
@@ -1,0 +1,39 @@
+'use strict';
+
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('boards', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+      },
+      board_id: {
+        allowNull: false,
+        type: Sequelize.STRING,
+      },
+      board_name: {
+        allowNull: false,
+        type: Sequelize.STRING,
+      },
+      board_user_token: {
+        allowNull: false,
+        type: Sequelize.STRING,
+      },
+      added_timestamp: {
+        allowNull: true,
+        type: Sequelize.DATE
+      },
+      updated_timestamp: {
+        allowNull: true,
+        type: Sequelize.DATE
+      },
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('boards');
+  }
+}

--- a/src/migrations/20191012141355-create-hub-profile.js
+++ b/src/migrations/20191012141355-create-hub-profile.js
@@ -1,0 +1,36 @@
+'use strict';
+
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('hub_profiles', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+      },
+      name: {
+        allowNull: false,
+        unique: true,
+        type: Sequelize.STRING,
+      },
+      settings: {
+        allowNull: false,
+        type: Sequelize.STRING,
+      },
+      added_timestamp: {
+        allowNull: true,
+        type: Sequelize.DATE
+      },
+      updated_timestamp: {
+        allowNull: true,
+        type: Sequelize.DATE
+      },
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('hub_profiles');
+  }
+}

--- a/src/migrations/20191012141435-create-hub.js
+++ b/src/migrations/20191012141435-create-hub.js
@@ -22,6 +22,26 @@ module.exports = {
           key: 'id',
         },
       },
+      board_id: {
+        allowNull: false,
+        type: Sequelize.INTEGER,
+        references: {
+          model: 'boards',
+          key: 'id',
+        },
+      },
+      hub_profile_id: {
+        allowNull: false,
+        type: Sequelize.INTEGER,
+        references: {
+          model: 'hub_profiles',
+          key: 'id',
+        },
+      },
+      hub_profile_settings: {
+        allowNull: false,
+        type: Sequelize.STRING,
+      },
       added_timestamp: {
         allowNull: true,
         type: Sequelize.DATE

--- a/src/models/board.js
+++ b/src/models/board.js
@@ -1,0 +1,50 @@
+'use strict';
+
+
+module.exports = (sequelize, DataTypes) => {
+  const board = sequelize.define('board', {
+    board_id: {
+        type: DataTypes.STRING,
+        allowNull: {
+          args: false,
+          msg: 'Board id needs to be present',
+        },
+      },
+    board_name: {
+      type: DataTypes.STRING,
+      allowNull: {
+        args: false,
+        msg: 'Board name from cloud must be present',
+      },
+    },
+    board_user_token: {
+        type: DataTypes.STRING,
+        allowNull: {
+          args: false,
+          msg: 'Board token must be provided',
+        },
+    },
+    added_timestamp: {
+      type: DataTypes.DATE,
+      allowNull: {
+        args: true,
+      },
+    },
+    updated_timestamp: {
+      type: DataTypes.DATE,
+      allowNull: {
+        args: true,
+      },
+    },
+  }, {
+    timestamps: false
+  });
+
+  board.associate = function(models) {
+    board.hasOne(models.hub, {
+      foreignKey: 'id',
+    });
+  };
+
+  return board;
+}

--- a/src/models/hub.js
+++ b/src/models/hub.js
@@ -2,6 +2,8 @@
 
 
 import user from './user';
+import board from './board';
+import hub_profile from './hub_profile';
 
 
 module.exports = (sequelize, DataTypes) => {
@@ -22,6 +24,35 @@ module.exports = (sequelize, DataTypes) => {
       references: {
         model: user,
         key: 'id',
+      },
+    },
+    board_id: {
+      type: DataTypes.INTEGER,
+      allowNull: {
+        args: false,
+        msg: 'Please specify board id',
+      },
+      references: {
+        model: board,
+        key: 'id',
+      },
+    },
+    hub_profile_id: {
+      type: DataTypes.INTEGER,
+      allowNull: {
+        args: false,
+        msg: 'Please specify hub profile id',
+      },
+      references: {
+        model: hub_profile,
+        key: 'id',
+      },
+    },
+    hub_profile_settings: {
+      type: DataTypes.STRING,
+      allowNull: {
+        args: false,
+        msg: 'Please enter hub profile settings',
       },
     },
     added_timestamp: {
@@ -46,6 +77,12 @@ module.exports = (sequelize, DataTypes) => {
     });
     hub.belongsTo(models.user, {
       foreignKey: 'user_id',
+    });
+    hub.belongsTo(models.board, {
+      foreignKey: 'board_id',
+    });
+    hub.belongsTo(models.hub_profile, {
+      foreignKey: 'hub_profile_id',
     });
   };
 

--- a/src/models/hub_profile.js
+++ b/src/models/hub_profile.js
@@ -1,0 +1,47 @@
+'use strict';
+
+
+module.exports = (sequelize, DataTypes) => {
+  const hub_profile = sequelize.define('hub_profile', {
+    name: {
+      type: DataTypes.STRING,
+      allowNull: {
+        args: false,
+        msg: 'Hub profile must have name',
+      },
+      unique: {
+        args: true,
+        msg: 'Hub profile with same name already exists',
+      },
+    },
+    settings: {
+        type: DataTypes.STRING,
+        allowNull: {
+          args: false,
+          msg: 'Hub profile needs to have required settings defined',
+        },
+    },
+    added_timestamp: {
+      type: DataTypes.DATE,
+      allowNull: {
+        args: true,
+      },
+    },
+    updated_timestamp: {
+      type: DataTypes.DATE,
+      allowNull: {
+        args: true,
+      },
+    },
+  }, {
+    timestamps: false
+  });
+
+  hub_profile.associate = function(models) {
+    hub_profile.hasMany(models.hub, {
+      foreignKey: 'id',
+    });
+  };
+
+  return hub_profile;
+}

--- a/src/routes/api/v1/boards/boards.js
+++ b/src/routes/api/v1/boards/boards.js
@@ -1,0 +1,14 @@
+import express from 'express';
+
+import controllers from 'src/controllers';
+import middlewares from 'src/middlewares';
+
+
+let router = express.Router();
+
+router.put('/:boardId', middlewares.cacheMiddlewares.prepareCacheHandler('boardId'), controllers.boardsController.updateBoard);
+
+router.delete('/:boardId', middlewares.cacheMiddlewares.prepareCacheHandler('boardId'), controllers.boardsController.deleteBoard);
+
+
+export default router;

--- a/src/routes/api/v1/boards/boardsCollection.js
+++ b/src/routes/api/v1/boards/boardsCollection.js
@@ -1,0 +1,14 @@
+import express from 'express';
+
+import controllers from 'src/controllers';
+import middlewares from 'src/middlewares';
+
+
+let router = express.Router();
+
+router.get('/', middlewares.cacheMiddlewares.prepareCacheHandler(), controllers.boardsController.getAllBoards);
+
+router.post('/', middlewares.cacheMiddlewares.prepareCacheHandler(), controllers.boardsController.addBoard);
+
+
+export default router;

--- a/src/routes/api/v1/boards/index.js
+++ b/src/routes/api/v1/boards/index.js
@@ -1,0 +1,13 @@
+import express from 'express';
+
+import boards from './boards';
+import boardsCollection from './boardsCollection';
+
+
+const router = express.Router();
+
+router.use('/', boards);
+router.use('/', boardsCollection);
+
+
+export default router;

--- a/src/routes/api/v1/hubProfiles/hubProfiles.js
+++ b/src/routes/api/v1/hubProfiles/hubProfiles.js
@@ -1,0 +1,14 @@
+import express from 'express';
+
+import controllers from 'src/controllers';
+import middlewares from 'src/middlewares';
+
+
+let router = express.Router();
+
+router.put('/:hubProfileId', middlewares.cacheMiddlewares.prepareCacheHandler('hubProfileId'), controllers.hubProfilesController.updateHubProfile);
+
+router.delete('/:hubProfileId', middlewares.cacheMiddlewares.prepareCacheHandler('hubProfileId'), controllers.hubProfilesController.deleteHubProfile);
+
+
+export default router;

--- a/src/routes/api/v1/hubProfiles/hubProfilesCollection.js
+++ b/src/routes/api/v1/hubProfiles/hubProfilesCollection.js
@@ -1,0 +1,14 @@
+import express from 'express';
+
+import controllers from 'src/controllers';
+import middlewares from 'src/middlewares';
+
+
+let router = express.Router();
+
+router.get('/', middlewares.cacheMiddlewares.prepareCacheHandler(), controllers.hubProfilesController.getAllHubProfiles);
+
+router.post('/', middlewares.cacheMiddlewares.prepareCacheHandler(), controllers.hubProfilesController.addHubProfile);
+
+
+export default router;

--- a/src/routes/api/v1/hubProfiles/index.js
+++ b/src/routes/api/v1/hubProfiles/index.js
@@ -1,0 +1,13 @@
+import express from 'express';
+
+import hubProfiles from './hubProfiles';
+import hubProfilesCollection from './hubProfilesCollection';
+
+
+const router = express.Router();
+
+router.use('/', hubProfiles);
+router.use('/', hubProfilesCollection);
+
+
+export default router;

--- a/src/routes/api/v1/index.js
+++ b/src/routes/api/v1/index.js
@@ -6,6 +6,8 @@ import users from './users';
 import roles from './roles';
 import hubs from './hubs';
 import categories from './categories';
+import boards from './boards';
+import hubProfiles from './hubProfiles';
 
 
 let router = express.Router();
@@ -16,6 +18,8 @@ router.use('/users', users);
 router.use('/roles', roles);
 router.use('/hubs', hubs);
 router.use('/categories', categories);
+router.use('/boards', boards);
+router.use('/hubProfiles', hubProfiles);
 
 
 export default router;

--- a/src/seeders/20191012141439-sample-tokens.js
+++ b/src/seeders/20191012141439-sample-tokens.js
@@ -5,7 +5,6 @@ module.exports = {
     up: (queryInterface, Sequelize) => {
         return queryInterface.bulkInsert('tokens', [
             {
-                id: 1,
                 owner_id: 1,
                 owner_type: 'USER',
                 token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImVtYWlsQGRvbWFpbi5jb20iLCJpYXQiOjE1OTMzNjkwNTIsImV4cCI6MTU5MzM3MjY1Mn0.eODrwAgllPj3YIeya-h3gvBK0yIH-mfrBUjRc6cnzFQ',

--- a/src/seeders/20191014210208-sample-boards.js
+++ b/src/seeders/20191014210208-sample-boards.js
@@ -1,0 +1,20 @@
+'use strict';
+
+
+module.exports = {
+    up: (queryInterface, Sequelize) => {
+        return queryInterface.bulkInsert('boards', [
+            {
+                board_id: 'board1',
+                board_name: 'photon_one',
+                board_user_token: 'boardTokenLalala',
+                added_timestamp: '2020-06-28T18:30:52.011Z',
+                updated_timestamp: null
+            }
+        ], {});
+    },
+
+    down: (queryInterface, Sequelize) => {
+        return queryInterface.bulkDelete('boards', null, {});
+    }
+}

--- a/src/seeders/20191014210209-sample-hub-profiles.js
+++ b/src/seeders/20191014210209-sample-hub-profiles.js
@@ -1,0 +1,19 @@
+'use strict';
+
+
+module.exports = {
+    up: (queryInterface, Sequelize) => {
+        return queryInterface.bulkInsert('hub_profiles', [
+            {
+                name: 'profileOne',
+                settings: 'settingsINJsonHere',
+                added_timestamp: '2020-06-28T18:30:52.011Z',
+                updated_timestamp: null
+            }
+        ], {});
+    },
+
+    down: (queryInterface, Sequelize) => {
+        return queryInterface.bulkDelete('hub_profiles', null, {});
+    }
+}

--- a/src/seeders/20191014210211-sample-hubs.js
+++ b/src/seeders/20191014210211-sample-hubs.js
@@ -6,6 +6,9 @@ module.exports = {
     return queryInterface.bulkInsert('hubs', [{
       name: 'Living room',
       user_id: 1,
+      board_id: 1,
+      hub_profile_id: 1,
+      hub_profile_settings: 'settingsWithValueAsJsonHere',
       added_timestamp: '2019-08-24T07:25:15.093Z',
     },
     ], {});


### PR DESCRIPTION
# **[Tasks](https://trello.com/c/v1IgsOc1/50-support-for-hub)**
The new hub idea, based on particle photon boards, needed a place to store board details such as id, token and name.
The `/boards` REST api endpoint has been implemented.
Also a profile for hubs were needed. Basically how the hub would work, what is it's role and what devices to expect/find and which pin etc.
The `/hubProfile` REST api endpoint has been implemented. This is now primarily be used to store pre-defined profile.

Also, updated hub migration, seeder and model accordingly.

Version bumped. Minor.

## Migrations:
- src/migrations/20191012141350-create-board.js
- src/migrations/20191012141355-create-hub-profile.js

## Seeders:
- src/seeders/20191014210208-sample-boards.js
- src/seeders/20191014210209-sample-hub-profiles.js

Not tests still :(