### PR TITLE
Babel config updated for development

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,22 +1,30 @@
 {
-  "presets": [
-    [
-      "@babel/preset-env",{
-        "targets": {
-          "node": "current"
-        }
-      }
-    ]
-  ],
-  "plugins": [
-    "@babel/plugin-proposal-class-properties",
-    ["module-resolver", {
-      "root": ["./"],
-      "alias": {
-        "projectRoot": "./",
-        "src": "./src"
-      }
-    }]
-  ],
-  "sourceMaps": "inline"
+    "env": {
+        "development": {
+            "presets": [
+                [
+                    "@babel/preset-env", {
+                        "targets": {
+                            "node": "current"
+                        }
+                    }
+                ]
+            ],
+            "plugins": [
+                "@babel/plugin-proposal-class-properties",
+                [
+                    "module-resolver", {
+                        "root": ["./"],
+                        "alias": {
+                            "projectRoot": "./",
+                            "src": "./src"
+                        }
+                    }
+                ]
+            ],
+            "sourceMaps": "inline"
+        },
+        "production": {},
+        "test": {}
+    }
 }

--- a/development.env
+++ b/development.env
@@ -1,4 +1,5 @@
-#NODE_ENV=development
+NODE_ENV=development
+BABEL_ENV=development
 #NODE_TLS_REJECT_UNAUTHORIZED=0
 TOKEN_SECRET=tokenSecret
 #NODE_EXTRA_CA_CERTS=./server.cert


### PR DESCRIPTION
# [Task](https://trello.com/c/XZ3OhxmN/64-babel-dev-prod-test-config) description
Now we have separate config for babel. Currently it holds only `development` since we are still in that phase of the application.